### PR TITLE
Modify the conditions of the coordinate comparing

### DIFF
--- a/jquery.tap.js
+++ b/jquery.tap.js
@@ -63,8 +63,8 @@
             // Coordinates, when event ends, should be the same as they were
             // on start.
             (
-              eventData.pageX === eventData.event.pageX &&
-              eventData.pageY === eventData.event.pageY
+              Math.abs(eventData.pageX - eventData.event.pageX) < 7 &&
+              Math.abs(eventData.pageY - eventData.event.pageY) < 7
             )
           ) {
             event.type = specialEventName;


### PR DESCRIPTION
On some mobile phone, I usually get two different but close start and end point values(eventData.pageX and eventData.event.pageX) when I touch on the same point, like "27.5" and "26.9687654125". In this case, the coordinate comparing will be "false", so that the "tap" event won't be triggered.

I modified the conditions of the coordinates comparing. Now it will be "true" when the end point is within 7 pixels from the start point.